### PR TITLE
Fix incorrect use of Browser API in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,15 @@ import { useClose, useOpen, availableFeatures } from '@capacitor-community/brows
 `useOpen`, `useClose` provides a way to launch, and close an in-app browser for external content:
 
 ```jsx
-useEffect(() => {
-  await useOpen('http://ionicframework.com');
-  await useClose();
-}, [useOpen, useClose]);
+// Open url in browser
+const { open } = useOpen();
+
+open({ url: 'http://ionicframework.com' });
+
+// Close url in browser
+const { close } = useClose();
+useClose()
+
 ```
 
 See the [Browser](https://capacitorjs.com/docs/apis/browser) Capacitor Plugin docs for more info on the plugin API.

--- a/README.md
+++ b/README.md
@@ -132,8 +132,7 @@ open({ url: 'http://ionicframework.com' });
 
 // Close url in browser
 const { close } = useClose();
-useClose()
-
+useClose();
 ```
 
 See the [Browser](https://capacitorjs.com/docs/apis/browser) Capacitor Plugin docs for more info on the plugin API.


### PR DESCRIPTION
The current browser hook documentation, pass the url parameter directly in the hook call. This causes the error `"Expected 0 arguments, but got 1"`.

I have updated the readme for its correct use.